### PR TITLE
PR - infra(fargate): add HTTPS listener + ACM cert; restrict ALB ingress CIDRs

### DIFF
--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -44,6 +44,52 @@ Additional settingsâ€”instance sizes, autoscaling thresholds, retention periodsâ
 
 ---
 
+## Security Configuration
+
+### HTTPS and TLS
+
+The Fargate ALB supports optional HTTPS with ACM certificates:
+
+- **Development:** HTTP-only mode is acceptable for testing (no certificate required)
+- **Production:** HTTPS is strongly recommended; provide an ACM certificate ARN via `search_service_acm_certificate_arn`
+
+When a certificate ARN is provided:
+- HTTPS listener is created on port 443 with TLS 1.3 policy (`ELBSecurityPolicy-TLS13-1-2-2021-06`)
+- HTTP port 80 redirects to HTTPS with a permanent (301) redirect
+- Security group allows both HTTP and HTTPS ingress from configured CIDRs
+
+When no certificate is provided:
+- HTTP listener forwards directly to the target group
+- No HTTPS listener is created
+- Security group allows only HTTP ingress
+
+**To enable HTTPS:**
+1. Create or import an ACM certificate in the deployment region
+2. Set `search_service_acm_certificate_arn` in terraform.tfvars
+3. Apply the Terraform configuration
+
+### Network Access Control
+
+The `search_service_allowed_ingress_cidrs` variable controls which IP ranges can access the ALB:
+
+- **Development:** `0.0.0.0/0` is acceptable for testing but not recommended
+- **Staging/Production:** Restrict to known CIDRs:
+  - Office/VPN IP ranges
+  - CloudFront prefix list (if using CDN)
+  - Partner API gateway IPs
+  - Internal VPC CIDR (for service-to-service calls)
+
+**Example production configuration:**
+```hcl
+search_service_allowed_ingress_cidrs = [
+  "203.0.113.0/24",    # Office network
+  "198.51.100.0/24",   # VPN range
+]
+search_service_acm_certificate_arn = "arn:aws:acm:us-east-1:123456789012:certificate/abcd1234-..."
+```
+
+---
+
 ## Remote State Backend
 
 All environments use **S3 + DynamoDB** for remote state storage and locking to enable team collaboration and prevent state corruption.

--- a/infrastructure/environments/dev/examples/fargate.tfvars.example
+++ b/infrastructure/environments/dev/examples/fargate.tfvars.example
@@ -7,11 +7,21 @@ embedding_backend                 = "bedrock"
 vector_store                      = "faiss"
 ingestion_mode                    = "batch"
 
-search_service_container_image    = "123456789012.dkr.ecr.us-east-1.amazonaws.com/semantic-search:main"
+search_service_container_image = "123456789012.dkr.ecr.us-east-1.amazonaws.com/semantic-search:main"
+
+# Network access control - restrict to known CIDRs for production
 search_service_allowed_ingress_cidrs = [
-  "203.0.113.0/24",
+  "203.0.113.0/24", # Example: Office network
+  # "198.51.100.0/24",  # Example: VPN range
+  # Add CloudFront prefix list or partner IPs as needed
 ]
-search_service_desired_count      = 2
+
+# HTTPS/TLS configuration - strongly recommended for production
+# Provide an ACM certificate ARN to enable HTTPS listener
+# When set, HTTP (port 80) redirects to HTTPS (port 443)
+search_service_acm_certificate_arn = "arn:aws:acm:us-east-1:123456789012:certificate/abcd1234-5678-90ef-ghij-klmnopqrstuv"
+
+search_service_desired_count = 2
 search_service_min_capacity       = 2
 search_service_max_capacity       = 6
 search_service_cpu                = 1024

--- a/infrastructure/environments/dev/main.tf
+++ b/infrastructure/environments/dev/main.tf
@@ -224,6 +224,7 @@ module "search_service_fargate" {
   public_subnet_ids               = module.core_network.public_subnet_ids
   additional_security_group_ids   = var.search_service_additional_security_group_ids
   allowed_ingress_cidrs           = var.search_service_allowed_ingress_cidrs
+  acm_certificate_arn             = var.search_service_acm_certificate_arn
   vector_store_endpoint           = local.vector_store_endpoint
   embedding_endpoint              = local.embedding_endpoint
   ingestion_queue_arn             = module.data_plane.ingestion_queue_arn
@@ -564,6 +565,12 @@ variable "search_service_allowed_ingress_cidrs" {
   type        = list(string)
   description = "CIDR blocks permitted to access the search service load balancer."
   default     = ["0.0.0.0/0"]
+}
+
+variable "search_service_acm_certificate_arn" {
+  type        = string
+  description = "ARN of the ACM certificate for HTTPS listener on the search service ALB. Leave empty to skip HTTPS."
+  default     = ""
 }
 
 variable "search_service_container_image" {

--- a/infrastructure/modules/search_service_fargate/main.tf
+++ b/infrastructure/modules/search_service_fargate/main.tf
@@ -169,6 +169,17 @@ resource "aws_security_group" "load_balancer" {
     cidr_blocks = var.allowed_ingress_cidrs
   }
 
+  dynamic "ingress" {
+    for_each = var.acm_certificate_arn != "" ? [1] : []
+    content {
+      description = "HTTPS"
+      from_port   = 443
+      to_port     = 443
+      protocol    = "tcp"
+      cidr_blocks = var.allowed_ingress_cidrs
+    }
+  }
+
   egress {
     description = "Outbound to tasks"
     from_port   = 0
@@ -209,10 +220,37 @@ resource "aws_lb_target_group" "this" {
   tags = local.common_tags
 }
 
+# HTTP listener: redirect to HTTPS if cert exists, otherwise forward
 resource "aws_lb_listener" "http" {
   load_balancer_arn = aws_lb.this.arn
   port              = 80
   protocol          = "HTTP"
+
+  default_action {
+    type = var.acm_certificate_arn != "" ? "redirect" : "forward"
+
+    dynamic "redirect" {
+      for_each = var.acm_certificate_arn != "" ? [1] : []
+      content {
+        port        = "443"
+        protocol    = "HTTPS"
+        status_code = "HTTP_301"
+      }
+    }
+
+    target_group_arn = var.acm_certificate_arn == "" ? aws_lb_target_group.this.arn : null
+  }
+}
+
+# HTTPS listener: only created when ACM cert is provided
+resource "aws_lb_listener" "https" {
+  count = var.acm_certificate_arn != "" ? 1 : 0
+
+  load_balancer_arn = aws_lb.this.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+  certificate_arn   = var.acm_certificate_arn
 
   default_action {
     type             = "forward"

--- a/infrastructure/modules/search_service_fargate/main.tf
+++ b/infrastructure/modules/search_service_fargate/main.tf
@@ -192,12 +192,13 @@ resource "aws_security_group" "load_balancer" {
 }
 
 resource "aws_lb" "this" {
-  name               = substr("${local.name_prefix}-alb", 0, 32)
-  internal           = false
-  load_balancer_type = "application"
-  subnets            = var.public_subnet_ids
-  security_groups    = [aws_security_group.load_balancer.id]
-  tags               = local.common_tags
+  name                       = substr("${local.name_prefix}-alb", 0, 32)
+  internal                   = false
+  load_balancer_type         = "application"
+  subnets                    = var.public_subnet_ids
+  security_groups            = [aws_security_group.load_balancer.id]
+  drop_invalid_header_fields = true
+  tags                       = local.common_tags
 }
 
 resource "aws_lb_target_group" "this" {

--- a/infrastructure/modules/search_service_fargate/variables.tf
+++ b/infrastructure/modules/search_service_fargate/variables.tf
@@ -56,6 +56,12 @@ variable "allowed_ingress_cidrs" {
   default     = ["0.0.0.0/0"]
 }
 
+variable "acm_certificate_arn" {
+  description = "ARN of the ACM certificate for HTTPS listener. Leave empty to skip HTTPS and use HTTP only (not recommended for production)."
+  type        = string
+  default     = ""
+}
+
 variable "container_image" {
   description = "Fully qualified container image URI for the semantic search runtime."
   type        = string


### PR DESCRIPTION
chore(infra): add https listener and restric alb ingress

Closes #34

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an optional HTTPS listener to the Fargate ALB (TLS 1.2+/1.3 via `ELBSecurityPolicy-TLS13-1-2-2021-06`), automatically redirecting HTTP → HTTPS with a 301 when an ACM certificate ARN is provided, and introduces a configurable `allowed_ingress_cidrs` variable to restrict ALB ingress away from the open-world default. The implementation is correct — the conditional redirect/forward logic, dynamic SG ingress rules, and `count`-gated HTTPS listener are all consistent — with one minor improvement available: a plan-time CIDR format validation on `allowed_ingress_cidrs`.

<h3>Confidence Score: 5/5</h3>

- Safe to merge; the only open finding is a P2 suggestion to add plan-time CIDR validation.
- All logic for the HTTPS listener, HTTP redirect, and security group conditional rules is correct. The sole remaining finding is a non-blocking style suggestion (missing validation block on `allowed_ingress_cidrs`), which does not affect runtime behaviour.
- No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| infrastructure/modules/search_service_fargate/main.tf | Adds conditional HTTPS listener (TLS 1.2+/1.3 policy), HTTP→HTTPS 301 redirect logic, and dynamic HTTPS ingress rule on the ALB SG. Implementation is correct: redirect/forward action types, dynamic blocks, and null target_group_arn are all handled consistently. |
| infrastructure/modules/search_service_fargate/variables.tf | Adds `acm_certificate_arn` and `allowed_ingress_cidrs` variables. `allowed_ingress_cidrs` lacks a CIDR format validation block; invalid values would only surface as opaque AWS API errors at apply time. |
| infrastructure/environments/dev/main.tf | Correctly plumbs `search_service_allowed_ingress_cidrs` and `search_service_acm_certificate_arn` through to the Fargate module. Variable declarations and module argument bindings are consistent. |
| infrastructure/environments/dev/examples/fargate.tfvars.example | New example tfvars demonstrating restricted ingress CIDRs and an ACM certificate ARN. Illustrative and well-commented. |
| infrastructure/README.md | Adds clear Security Configuration section covering HTTPS/TLS behaviour (redirect vs. forward, SSL policy) and Network Access Control guidance for the new variables. |

</details>


</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `infrastructure/modules/search_service_fargate/main.tf`, line 194-201 ([link](https://github.com/bytes0211/semantic_search/blob/4ad65b42abab508708805ccfbc923d2731cc34e4/infrastructure/modules/search_service_fargate/main.tf#L194-L201)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> <a href="#"><img alt="security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=1" align="top"></a> **Missing `drop_invalid_header_fields` on ALB**

   The `aws_lb` resource doesn't set `drop_invalid_header_fields = true`. Without this, the ALB forwards requests containing malformed or ambiguous headers to targets, which enables HTTP request-smuggling / desync attacks. Since this PR is a security-hardening change, enabling this flag here is a natural addition.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: infrastructure/modules/search_service_fargate/main.tf
   Line: 194-201

   Comment:
   **Missing `drop_invalid_header_fields` on ALB**

   The `aws_lb` resource doesn't set `drop_invalid_header_fields = true`. Without this, the ALB forwards requests containing malformed or ambiguous headers to targets, which enables HTTP request-smuggling / desync attacks. Since this PR is a security-hardening change, enabling this flag here is a natural addition.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: infrastructure/modules/search_service_fargate/variables.tf
Line: 53-57

Comment:
**Missing CIDR format validation on `allowed_ingress_cidrs`**

Without a validation block, an invalid CIDR string (e.g. `"10.0.0"`) is only caught at `apply` time as an AWS API error. Adding a plan-time check gives callers an early, actionable message.

```suggestion
variable "allowed_ingress_cidrs" {
  description = "CIDR ranges permitted to access the ALB listener."
  type        = list(string)
  default     = ["0.0.0.0/0"]

  validation {
    condition     = alltrue([for cidr in var.allowed_ingress_cidrs : can(cidrhost(cidr, 0))])
    error_message = "All values in allowed_ingress_cidrs must be valid CIDR blocks (e.g. \"10.0.0.0/8\")."
  }
}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(infra):addressed comments in PR 41 c..."](https://github.com/bytes0211/semantic_search/commit/cca3d944590359e99476ba7e33cdfee0a3676e00) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28394565)</sub>

<!-- /greptile_comment -->