### PR TITLE
PR - infra(network): move Fargate tasks to private subnets behind NAT or VPC endpoints

### DIFF
--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -116,6 +116,10 @@ create_nat_gateway              = true   # Or enable_interface_endpoints = true
 search_service_assign_public_ip = false  # Tasks use private IPs only
 ```
 
+**Important limitations:**
+- **Single NAT Gateway:** The default configuration provisions one NAT gateway in the first availability zone only. Tasks in other AZs route egress traffic cross-AZ through this single NAT gateway. If that AZ experiences degradation, all private subnet egress fails, despite the multi-AZ ECS deployment. For production environments requiring AZ-level fault isolation, consider enabling VPC interface endpoints instead (`enable_interface_endpoints = true`), which are provisioned per-AZ automatically.
+- **Egress precondition:** Terraform enforces that at least one egress mechanism is enabled when tasks are in private subnets. If `create_nat_gateway`, `enable_interface_endpoints`, and `search_service_assign_public_ip` are all `false`, the apply will fail with a precondition error.
+
 When disabling the NAT gateway or VPC endpoints (e.g., for local testing), tasks can be placed in public subnets with `assign_public_ip = true`, but this configuration **is not recommended for production** as it exposes container instances directly to the internet.
 
 ---

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -88,6 +88,36 @@ search_service_allowed_ingress_cidrs = [
 search_service_acm_certificate_arn = "arn:aws:acm:us-east-1:123456789012:certificate/abcd1234-..."
 ```
 
+### Private Subnets and NAT Gateway
+
+Fargate tasks run in **private subnets** for security hardening and do not receive public IP addresses. Outbound connectivity to AWS services (ECR, Bedrock, S3) and the internet is provided through a **NAT gateway** or **VPC endpoints**.
+
+**Configuration options:**
+
+1. **NAT Gateway (default)** — Simplest option, provides general internet egress for all services
+   - Cost: ~$32/month per AZ plus data transfer charges
+   - Set `create_nat_gateway = true` in terraform.tfvars
+   - Tasks automatically route all egress through the NAT gateway
+   
+2. **VPC Endpoints** — Lower cost for specific AWS services, no internet egress
+   - Cost: ~$7/month per interface endpoint (e.g., ECR, Bedrock)
+   - Set `enable_interface_endpoints = true` in terraform.tfvars
+   - Requires endpoint configuration for each required service
+   - No internet access (outbound HTTPS is blocked except to AWS services)
+
+**Network flow:**
+- Internet → ALB (public subnets) → Fargate tasks (private subnets)
+- Fargate tasks → NAT gateway (public subnet) → Internet Gateway → AWS services/Internet
+- Or: Fargate tasks → VPC endpoints (private subnets) → AWS services directly
+
+**Required settings:**
+```hcl
+create_nat_gateway              = true   # Or enable_interface_endpoints = true
+search_service_assign_public_ip = false  # Tasks use private IPs only
+```
+
+When disabling the NAT gateway or VPC endpoints (e.g., for local testing), tasks can be placed in public subnets with `assign_public_ip = true`, but this configuration **is not recommended for production** as it exposes container instances directly to the internet.
+
 ---
 
 ## Remote State Backend

--- a/infrastructure/environments/dev/main.tf
+++ b/infrastructure/environments/dev/main.tf
@@ -33,7 +33,7 @@ module "core_network" {
   environment               = var.environment
   vpc_cidr                  = var.vpc_cidr
   default_az_count          = var.default_az_count
-  create_nat_gateway        = false
+  create_nat_gateway        = var.create_nat_gateway
   enable_internet_gateway   = true
   enable_flow_logs          = var.enable_flow_logs
   flow_log_destination_type = var.flow_log_destination_type
@@ -218,9 +218,8 @@ module "search_service_fargate" {
   environment = var.environment
   aws_region  = var.aws_region
   vpc_id      = module.core_network.vpc_id
-  # In dev there is no NAT gateway; tasks use public subnets with assign_public_ip=true
-  # so they can reach ECR and Bedrock without a NAT.
-  subnet_ids                      = module.core_network.public_subnet_ids
+  # Tasks run in private subnets; egress via NAT gateway or VPC endpoints
+  subnet_ids                      = module.core_network.private_subnet_ids
   public_subnet_ids               = module.core_network.public_subnet_ids
   additional_security_group_ids   = var.search_service_additional_security_group_ids
   allowed_ingress_cidrs           = var.search_service_allowed_ingress_cidrs
@@ -494,6 +493,12 @@ variable "vpc_cidr" {
   type        = string
   description = "CIDR block allocated to the VPC."
   default     = "10.42.0.0/16"
+}
+
+variable "create_nat_gateway" {
+  type        = bool
+  description = "Whether to provision a managed NAT gateway for private subnet egress (~$32/mo/AZ). Required when assign_public_ip = false."
+  default     = false
 }
 
 variable "default_az_count" {

--- a/infrastructure/environments/dev/main.tf
+++ b/infrastructure/environments/dev/main.tf
@@ -624,6 +624,11 @@ variable "search_service_assign_public_ip" {
   type        = bool
   description = "Assign a public IP to the Fargate tasks."
   default     = false
+
+  validation {
+    condition     = var.search_service_assign_public_ip || var.create_nat_gateway || var.enable_interface_endpoints
+    error_message = "Private-subnet Fargate tasks require at least one egress path: set create_nat_gateway=true, enable_interface_endpoints=true, or search_service_assign_public_ip=true."
+  }
 }
 
 variable "search_service_platform_version" {


### PR DESCRIPTION
chore(infra): secure fargate tasks

Closes #35

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves the Fargate search service from public to private subnets, adds `create_nat_gateway`, `enable_s3_endpoint`, and `enable_interface_endpoints` variables, and introduces a validation guard on `search_service_assign_public_ip` to prevent misconfigured no-egress deployments. Two blocking issues remain:

- The validation condition for `search_service_assign_public_ip` cross-references `var.create_nat_gateway` and `var.enable_interface_endpoints`, which is only valid in Terraform ≥ 1.9.0. With `required_version = \">= 1.5.0\"`, this breaks `plan`/`validate` on Terraform 1.5–1.8.
- The README and validation both treat `enable_interface_endpoints = true` as a complete egress solution, but data plane S3 operations (canonical bucket, embeddings bucket, FAISS index) have no path to S3 unless `enable_s3_endpoint = true` is also set.

<h3>Confidence Score: 3/5</h3>

Not safe to merge — two P1 issues: Terraform 1.5–1.8 incompatibility in the validation block, and an incomplete VPC-endpoint egress path that silently breaks S3 data plane access.

Both findings are present defects on the changed code paths. The cross-variable validation breaks terraform plan on the declared minimum version. The missing S3 endpoint leaves the VPC-endpoint egress path documented and validated as sufficient when it isn't, causing runtime failures for data plane S3 operations.

Both infrastructure/environments/dev/main.tf (validation block) and infrastructure/README.md (VPC endpoint guidance) require fixes before this is safe to merge.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| infrastructure/environments/dev/main.tf | Moves Fargate tasks to private subnets, adds NAT/VPC-endpoint variables, and adds a cross-variable validation guard — but the guard uses Terraform 1.9+ syntax while `required_version = ">= 1.5.0"`, breaking older installs. |
| infrastructure/README.md | Adds private-subnet networking documentation; the VPC endpoint guidance omits the required `enable_s3_endpoint = true` co-requisite, which will cause data plane S3 access to fail when NAT is disabled. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: infrastructure/environments/dev/main.tf
Line: 628-632

Comment:
**Cross-variable validation requires Terraform ≥ 1.9.0**

The `condition` expression references `var.create_nat_gateway` and `var.enable_interface_endpoints` from within a validation block for a *different* variable (`search_service_assign_public_ip`). Cross-variable references inside `validation` blocks were introduced in **Terraform 1.9.0**. With `required_version = ">= 1.5.0"`, this configuration fails `terraform validate` and `terraform plan` on any Terraform 1.5–1.8 installation with "A validation condition may only reference the variable being validated."

Either raise the minimum version to `>= 1.9.0`, or enforce the constraint via a `locals` block + `lifecycle { precondition }` on a downstream resource (as was suggested in the previous review thread on this PR) so it works across the full declared version range.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: infrastructure/README.md
Line: 101-106

Comment:
**VPC endpoint egress path omits the required S3 gateway endpoint**

The README instructs users to set only `enable_interface_endpoints = true` for private-subnet egress. In this mode, the data plane modules (`data_plane`, `embedding_*`, `vector_store_*`) all access S3 buckets (canonical, embeddings, FAISS index). With no NAT gateway and no S3 gateway endpoint, those S3 API calls have no route and the tasks fail at runtime with connection timeouts.

`core_network`'s `active_interface_endpoints` map covers SQS, SNS, Bedrock, CloudWatch Logs, ECR API, and ECR DKR — but **not** S3. An S3 gateway endpoint (`enable_s3_endpoint = true`) is free/low-cost and must accompany the interface endpoints whenever NAT is disabled. The "VPC Endpoints" option description should call out `enable_s3_endpoint = true` as a co-requisite.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(infra): address comments in PR 42 co..."](https://github.com/bytes0211/semantic_search/commit/948150e1e0f93cfa722687f05e71867b0153d4f4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28399629)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->