### PR TITLE
PR - infra(sg): tighten unrestricted egress on Fargate/Lambda/ALB security groups

### DIFF
--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -127,9 +127,10 @@ When disabling the NAT gateway or VPC endpoints (e.g., for local testing), tasks
 The `restrict_egress` variable controls outbound traffic from Fargate tasks, Lambda functions, and the ALB security groups.
 
 **When `restrict_egress = true` (default, recommended):**
-- Fargate task and Lambda security groups: HTTPS egress (port 443) scoped to VPC CIDR only
+- Fargate task and Lambda security groups: HTTPS egress (port 443) only, all destinations
 - ALB security group: TCP egress on container port scoped to VPC CIDR only (for forwarding to tasks)
-- Requires either NAT gateway or VPC endpoints for AWS service access
+- Blocks all non-HTTPS protocols and ports
+- Works with both NAT gateway (public endpoints) and VPC endpoints (private endpoints)
 - Minimizes blast radius if a workload is compromised
 
 **When `restrict_egress = false` (opt-in, development only):**
@@ -140,7 +141,7 @@ The `restrict_egress` variable controls outbound traffic from Fargate tasks, Lam
 **Example production configuration:**
 ```hcl
 create_nat_gateway = true   # Provides egress for all AWS services
-restrict_egress    = true   # Default; scopes all security group egress to VPC CIDR
+restrict_egress    = true   # Default; restricts protocols/ports (HTTPS only)
 ```
 
 **To disable egress restrictions (development only):**
@@ -148,9 +149,9 @@ restrict_egress    = true   # Default; scopes all security group egress to VPC C
 restrict_egress = false   # Allows unrestricted egress — NOT for production
 ```
 
-**Prerequisites for `restrict_egress = true`:**
+**Prerequisites:**
 - At least one egress path must be provisioned (`create_nat_gateway = true` OR `enable_interface_endpoints = true`)
-- VPC CIDR must be set (automatically provided via `var.vpc_cidr`)
+- When using Fargate, VPC CIDR must be set for ALB egress rules (automatically provided via `var.vpc_cidr`)
 
 ---
 

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -126,23 +126,29 @@ When disabling the NAT gateway or VPC endpoints (e.g., for local testing), tasks
 
 The `restrict_egress` variable controls outbound traffic from Fargate tasks, Lambda functions, and the ALB security groups.
 
-**When `restrict_egress = false` (default for development):**
+**When `restrict_egress = true` (default, recommended):**
+- Fargate task and Lambda security groups: HTTPS egress (port 443) scoped to VPC CIDR only
+- ALB security group: TCP egress on container port scoped to VPC CIDR only (for forwarding to tasks)
+- Requires either NAT gateway or VPC endpoints for AWS service access
+- Minimizes blast radius if a workload is compromised
+
+**When `restrict_egress = false` (opt-in, development only):**
 - All security groups allow unrestricted egress (`0.0.0.0/0`) on all ports
 - Simplifies initial setup and troubleshooting
-- **Not recommended for production** — widens blast radius if a workload is compromised
-
-**When `restrict_egress = true` (recommended for production):**
-- Fargate task and Lambda security groups: HTTPS egress (port 443) scoped to VPC CIDR only
-- ALB security group: All egress scoped to VPC CIDR only (for forwarding to tasks)
-- Requires either NAT gateway or VPC endpoints for AWS service access
+- **Not recommended for production** — widens attack surface
 
 **Example production configuration:**
 ```hcl
 create_nat_gateway = true   # Provides egress for all AWS services
-restrict_egress    = true   # Scopes all security group egress to VPC CIDR
+restrict_egress    = true   # Default; scopes all security group egress to VPC CIDR
 ```
 
-**Prerequisites for enabling `restrict_egress = true`:**
+**To disable egress restrictions (development only):**
+```hcl
+restrict_egress = false   # Allows unrestricted egress — NOT for production
+```
+
+**Prerequisites for `restrict_egress = true`:**
 - At least one egress path must be provisioned (`create_nat_gateway = true` OR `enable_interface_endpoints = true`)
 - VPC CIDR must be set (automatically provided via `var.vpc_cidr`)
 

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -122,6 +122,30 @@ search_service_assign_public_ip = false  # Tasks use private IPs only
 
 When disabling the NAT gateway or VPC endpoints (e.g., for local testing), tasks can be placed in public subnets with `assign_public_ip = true`, but this configuration **is not recommended for production** as it exposes container instances directly to the internet.
 
+### Security Group Egress Restrictions
+
+The `restrict_egress` variable controls outbound traffic from Fargate tasks, Lambda functions, and the ALB security groups.
+
+**When `restrict_egress = false` (default for development):**
+- All security groups allow unrestricted egress (`0.0.0.0/0`) on all ports
+- Simplifies initial setup and troubleshooting
+- **Not recommended for production** — widens blast radius if a workload is compromised
+
+**When `restrict_egress = true` (recommended for production):**
+- Fargate task and Lambda security groups: HTTPS egress (port 443) scoped to VPC CIDR only
+- ALB security group: All egress scoped to VPC CIDR only (for forwarding to tasks)
+- Requires either NAT gateway or VPC endpoints for AWS service access
+
+**Example production configuration:**
+```hcl
+create_nat_gateway = true   # Provides egress for all AWS services
+restrict_egress    = true   # Scopes all security group egress to VPC CIDR
+```
+
+**Prerequisites for enabling `restrict_egress = true`:**
+- At least one egress path must be provisioned (`create_nat_gateway = true` OR `enable_interface_endpoints = true`)
+- VPC CIDR must be set (automatically provided via `var.vpc_cidr`)
+
 ---
 
 ## Remote State Backend

--- a/infrastructure/environments/dev/examples/fargate.tfvars.example
+++ b/infrastructure/environments/dev/examples/fargate.tfvars.example
@@ -7,6 +7,18 @@ embedding_backend                 = "bedrock"
 vector_store                      = "faiss"
 ingestion_mode                    = "batch"
 
+# ─── Network Configuration ────────────────────────────────────────────────────
+# Enable NAT gateway for private subnet egress (~$32/mo/AZ) OR enable interface 
+# endpoints (~$7/mo per endpoint). At least one egress path is required when 
+# search_service_assign_public_ip = false.
+create_nat_gateway         = true
+enable_interface_endpoints = false
+
+# Restrict security group egress to VPC CIDR only (HTTPS port 443)
+# Set to false for unrestricted internet egress (not recommended for production)
+restrict_egress = true
+
+# ─── Search Service Configuration ─────────────────────────────────────────────
 search_service_container_image = "123456789012.dkr.ecr.us-east-1.amazonaws.com/semantic-search:main"
 
 # Network access control - restrict to known CIDRs for production

--- a/infrastructure/environments/dev/examples/fargate.tfvars.example
+++ b/infrastructure/environments/dev/examples/fargate.tfvars.example
@@ -14,9 +14,9 @@ ingestion_mode                    = "batch"
 create_nat_gateway         = true
 enable_interface_endpoints = false
 
-# Restrict security group egress to VPC CIDR only (HTTPS port 443)
-# Set to false for unrestricted internet egress (not recommended for production)
-restrict_egress = true
+# Restrict security group egress to VPC CIDR only (default = true, secure-by-default)
+# Uncomment to allow unrestricted egress (development only, NOT for production)
+# restrict_egress = false
 
 # ─── Search Service Configuration ─────────────────────────────────────────────
 search_service_container_image = "123456789012.dkr.ecr.us-east-1.amazonaws.com/semantic-search:main"

--- a/infrastructure/environments/dev/examples/fargate.tfvars.example
+++ b/infrastructure/environments/dev/examples/fargate.tfvars.example
@@ -14,8 +14,9 @@ ingestion_mode                    = "batch"
 create_nat_gateway         = true
 enable_interface_endpoints = false
 
-# Restrict security group egress to VPC CIDR only (default = true, secure-by-default)
-# Uncomment to allow unrestricted egress (development only, NOT for production)
+# Security group egress restriction (default = true)
+# When true: allows HTTPS (port 443) only; blocks all other protocols/ports
+# When false: unrestricted egress (development only, NOT for production)
 # restrict_egress = false
 
 # ─── Search Service Configuration ─────────────────────────────────────────────

--- a/infrastructure/environments/dev/examples/lambda.tfvars.example
+++ b/infrastructure/environments/dev/examples/lambda.tfvars.example
@@ -14,9 +14,9 @@ ingestion_mode              = "batch"
 create_nat_gateway         = true
 enable_interface_endpoints = false
 
-# Restrict security group egress to VPC CIDR only (HTTPS port 443)
-# Set to false for unrestricted internet egress (not recommended for production)
-restrict_egress = true
+# Restrict security group egress to VPC CIDR only (default = true, secure-by-default)
+# Uncomment to allow unrestricted egress (development only, NOT for production)
+# restrict_egress = false
 
 # ─── Lambda Configuration ─────────────────────────────────────────────────────
 # Container image published by the shared build pipeline

--- a/infrastructure/environments/dev/examples/lambda.tfvars.example
+++ b/infrastructure/environments/dev/examples/lambda.tfvars.example
@@ -7,6 +7,18 @@ embedding_backend           = "sagemaker"
 vector_store                = "pgvector"
 ingestion_mode              = "batch"
 
+# ─── Network Configuration ────────────────────────────────────────────────────
+# Enable NAT gateway for private subnet egress (~$32/mo/AZ) OR enable interface 
+# endpoints (~$7/mo per endpoint). Lambda functions require egress for accessing 
+# AWS services (S3, SageMaker, CloudWatch Logs).
+create_nat_gateway         = true
+enable_interface_endpoints = false
+
+# Restrict security group egress to VPC CIDR only (HTTPS port 443)
+# Set to false for unrestricted internet egress (not recommended for production)
+restrict_egress = true
+
+# ─── Lambda Configuration ─────────────────────────────────────────────────────
 # Container image published by the shared build pipeline
 lambda_container_image      = "123456789012.dkr.ecr.us-east-1.amazonaws.com/semantic-search:main"
 lambda_timeout_seconds      = 20

--- a/infrastructure/environments/dev/examples/lambda.tfvars.example
+++ b/infrastructure/environments/dev/examples/lambda.tfvars.example
@@ -14,8 +14,9 @@ ingestion_mode              = "batch"
 create_nat_gateway         = true
 enable_interface_endpoints = false
 
-# Restrict security group egress to VPC CIDR only (default = true, secure-by-default)
-# Uncomment to allow unrestricted egress (development only, NOT for production)
+# Security group egress restriction (default = true)
+# When true: allows HTTPS (port 443) only; blocks all other protocols/ports
+# When false: unrestricted egress (development only, NOT for production)
 # restrict_egress = false
 
 # ─── Lambda Configuration ─────────────────────────────────────────────────────

--- a/infrastructure/modules/search_service_fargate/main.tf
+++ b/infrastructure/modules/search_service_fargate/main.tf
@@ -180,12 +180,26 @@ resource "aws_security_group" "load_balancer" {
     }
   }
 
-  egress {
-    description = "Outbound to tasks"
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
+  dynamic "egress" {
+    for_each = var.restrict_egress ? [] : [1]
+    content {
+      description = "Outbound to tasks (unrestricted)"
+      from_port   = 0
+      to_port     = 0
+      protocol    = "-1"
+      cidr_blocks = ["0.0.0.0/0"]
+    }
+  }
+
+  dynamic "egress" {
+    for_each = var.restrict_egress ? [1] : []
+    content {
+      description = "Outbound to tasks in VPC"
+      from_port   = 0
+      to_port     = 0
+      protocol    = "-1"
+      cidr_blocks = [var.vpc_cidr]
+    }
   }
 
   tags = local.common_tags

--- a/infrastructure/modules/search_service_fargate/main.tf
+++ b/infrastructure/modules/search_service_fargate/main.tf
@@ -195,9 +195,9 @@ resource "aws_security_group" "load_balancer" {
     for_each = var.restrict_egress ? [1] : []
     content {
       description = "Outbound to tasks in VPC"
-      from_port   = 0
-      to_port     = 0
-      protocol    = "-1"
+      from_port   = var.container_port
+      to_port     = var.container_port
+      protocol    = "tcp"
       cidr_blocks = [var.vpc_cidr]
     }
   }

--- a/infrastructure/modules/search_service_fargate/main.tf
+++ b/infrastructure/modules/search_service_fargate/main.tf
@@ -145,11 +145,11 @@ resource "aws_security_group" "service" {
   dynamic "egress" {
     for_each = var.restrict_egress ? [1] : []
     content {
-      description = "HTTPS to VPC CIDR (VPC endpoints)"
+      description = "HTTPS egress (NAT gateway or VPC endpoints)"
       from_port   = 443
       to_port     = 443
       protocol    = "tcp"
-      cidr_blocks = [var.vpc_cidr]
+      cidr_blocks = ["0.0.0.0/0"]
     }
   }
 

--- a/infrastructure/modules/search_service_fargate/variables.tf
+++ b/infrastructure/modules/search_service_fargate/variables.tf
@@ -311,13 +311,13 @@ variable "deny_guardrail_policy_json" {
 
 variable "restrict_egress" {
   type        = bool
-  description = "When true, replace the all-traffic egress rule on the service SG with HTTPS-only (443) to the VPC CIDR."
+  description = "When true, restrict service SG to HTTPS-only (443) egress and ALB SG to container-port-only egress within VPC."
   default     = true
 }
 
 variable "vpc_cidr" {
   type        = string
-  description = "VPC CIDR block used for scoped egress rules when restrict_egress is true."
+  description = "VPC CIDR block used for scoped ALB egress rules when restrict_egress is true."
   default     = ""
 
   validation {

--- a/infrastructure/modules/search_service_fargate/variables.tf
+++ b/infrastructure/modules/search_service_fargate/variables.tf
@@ -312,7 +312,7 @@ variable "deny_guardrail_policy_json" {
 variable "restrict_egress" {
   type        = bool
   description = "When true, replace the all-traffic egress rule on the service SG with HTTPS-only (443) to the VPC CIDR."
-  default     = false
+  default     = true
 }
 
 variable "vpc_cidr" {

--- a/infrastructure/modules/search_service_lambda/main.tf
+++ b/infrastructure/modules/search_service_lambda/main.tf
@@ -109,11 +109,11 @@ resource "aws_security_group" "lambda" {
   dynamic "egress" {
     for_each = var.restrict_egress ? [1] : []
     content {
-      description = "HTTPS to VPC CIDR (VPC endpoints)"
+      description = "HTTPS egress (NAT gateway or VPC endpoints)"
       from_port   = 443
       to_port     = 443
       protocol    = "tcp"
-      cidr_blocks = [var.vpc_cidr]
+      cidr_blocks = ["0.0.0.0/0"]
     }
   }
 

--- a/infrastructure/modules/search_service_lambda/variables.tf
+++ b/infrastructure/modules/search_service_lambda/variables.tf
@@ -232,17 +232,12 @@ variable "deny_guardrail_policy_json" {
 
 variable "restrict_egress" {
   type        = bool
-  description = "When true, replace the all-traffic egress rule on the Lambda SG with HTTPS-only (443) to the VPC CIDR."
+  description = "When true, restrict Lambda SG to HTTPS-only (443) egress."
   default     = true
 }
 
 variable "vpc_cidr" {
   type        = string
-  description = "VPC CIDR block used for scoped egress rules when restrict_egress is true."
+  description = "VPC CIDR block (currently unused by Lambda module but kept for API consistency)."
   default     = ""
-
-  validation {
-    condition     = !var.restrict_egress || var.vpc_cidr != ""
-    error_message = "vpc_cidr must be a non-empty CIDR block when restrict_egress is true."
-  }
 }

--- a/infrastructure/modules/search_service_lambda/variables.tf
+++ b/infrastructure/modules/search_service_lambda/variables.tf
@@ -233,7 +233,7 @@ variable "deny_guardrail_policy_json" {
 variable "restrict_egress" {
   type        = bool
   description = "When true, replace the all-traffic egress rule on the Lambda SG with HTTPS-only (443) to the VPC CIDR."
-  default     = false
+  default     = true
 }
 
 variable "vpc_cidr" {


### PR DESCRIPTION
chore(infra): tighten unrestricted egress on fargate

Closes #36

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR tightens security group egress for the Fargate service SG, ALB SG, and Lambda SG by introducing a `restrict_egress` toggle (default `true`) that limits outbound traffic to HTTPS-only (port 443) and, for the ALB, to the container port within the VPC CIDR. The Fargate side is well-implemented; the Lambda module has three issues that need attention before merge:

- `aws_security_group.lambda` is created unconditionally, forcing `vpc_id` to be supplied even when `subnet_ids = []` (no VPC attachment), resulting in an orphaned SG and a misleading required variable.
- `var.vpc_id` has no default, making non-VPC Lambda deployments impossible without a dummy value.
- `aws_iam_role_policy.secrets_access` lacks the `count` guard present in the Fargate module; it will fail with an IAM policy-parsing error when `secret_arn_values = {}`.

<h3>Confidence Score: 3/5</h3>

Not safe to merge as-is; Lambda module has three defects that will cause apply failures for certain valid input combinations.

Two P1 defects in the Lambda module (unconditional SG creation breaking non-VPC deployments; empty-Resource IAM policy causing apply failure) need to be fixed before merging. The Fargate changes are solid and address prior review concerns correctly.

infrastructure/modules/search_service_lambda/main.tf and infrastructure/modules/search_service_lambda/variables.tf require fixes for SG conditionality and the secrets_access policy guard.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| infrastructure/modules/search_service_fargate/main.tf | Adds conditional egress rules to both the Fargate service SG (HTTPS-only to 0.0.0.0/0) and the ALB SG (container port scoped to vpc_cidr) when restrict_egress=true; ALB egress is now correctly scoped to container_port rather than all-ports. |
| infrastructure/modules/search_service_fargate/variables.tf | Adds restrict_egress (default true) and vpc_cidr variables with a validation guard that vpc_cidr must be non-empty when restrict_egress is true; well-formed. |
| infrastructure/modules/search_service_lambda/main.tf | Adds new aws_security_group.lambda resource and conditional egress rules, but the SG is created unconditionally regardless of subnet_ids, forcing vpc_id on non-VPC deployments; secrets_access policy also lacks a count guard and will fail when secret_arn_values is empty. |
| infrastructure/modules/search_service_lambda/variables.tf | Adds restrict_egress (default true) and vpc_cidr (unused, for API parity) variables; vpc_id has no default but is required by the unconditionally created SG even when Lambda is not VPC-attached. |
| infrastructure/environments/dev/examples/fargate.tfvars.example | Adds a commented-out restrict_egress block with inline guidance; the NAT-only + restrict_egress=true (default) combination is now safe since the service SG allows port-443 to 0.0.0.0/0. |
| infrastructure/environments/dev/examples/lambda.tfvars.example | Adds commented-out restrict_egress guidance matching the Fargate example; no issues. |
| infrastructure/README.md | New Security Group Egress Restrictions section documents restrict_egress behavior for Fargate, Lambda, and ALB SGs accurately. |

</details>


</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `infrastructure/modules/search_service_fargate/variables.tf`, line 312-316 ([link](https://github.com/bytes0211/semantic_search/blob/ba62c47c3b51146a3764edda320a2111db443925/infrastructure/modules/search_service_fargate/variables.tf#L312-L316)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`restrict_egress` defaults to the insecure path**

   Both the Fargate and Lambda modules default `restrict_egress` to `false`, meaning anyone invoking the module without explicit tfvars inherits unrestricted egress (`0.0.0.0/0`). The example files now correctly set `restrict_egress = true`, but the module-level default works against the hardening goal of this PR. Consider flipping the default to `true` (with `vpc_cidr` being required when that flag is set) so the secure path is opt-out rather than opt-in. The same change applies to `infrastructure/modules/search_service_lambda/variables.tf` line 234.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: infrastructure/modules/search_service_fargate/variables.tf
   Line: 312-316

   Comment:
   **`restrict_egress` defaults to the insecure path**

   Both the Fargate and Lambda modules default `restrict_egress` to `false`, meaning anyone invoking the module without explicit tfvars inherits unrestricted egress (`0.0.0.0/0`). The example files now correctly set `restrict_egress = true`, but the module-level default works against the hardening goal of this PR. Consider flipping the default to `true` (with `vpc_cidr` being required when that flag is set) so the secure path is opt-out rather than opt-in. The same change applies to `infrastructure/modules/search_service_lambda/variables.tf` line 234.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `infrastructure/modules/search_service_lambda/main.tf`, line 93-121 ([link](https://github.com/bytes0211/semantic_search/blob/09d40b60d11e5e638160fc91732f36e1bcac3476/infrastructure/modules/search_service_lambda/main.tf#L93-L121)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Lambda SG created unconditionally, forcing `vpc_id` on non-VPC deployments**

   `aws_security_group.lambda` is created on every invocation of this module, but the SG is only ever attached to the function when `length(var.subnet_ids) > 0` (the `vpc_config` dynamic block). `var.vpc_id` has no default, so callers who set `subnet_ids = []` to skip VPC attachment must still supply a `vpc_id` to satisfy the SG resource — contradicting the variable's own description ("VPC identifier used when the Lambda function runs inside a VPC"). This produces an orphaned, unused security group and a misleading required variable.

   The SG creation should mirror the `vpc_config` condition:

   ```hcl
   resource "aws_security_group" "lambda" {
     count       = length(var.subnet_ids) > 0 ? 1 : 0
     name        = "${local.name_prefix}-sg"
     description = "Security group for Lambda search runtime"
     vpc_id      = var.vpc_id
     ...
   }
   ```

   And the `vpc_config` reference updated to `aws_security_group.lambda[0].id`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: infrastructure/modules/search_service_lambda/main.tf
   Line: 93-121

   Comment:
   **Lambda SG created unconditionally, forcing `vpc_id` on non-VPC deployments**

   `aws_security_group.lambda` is created on every invocation of this module, but the SG is only ever attached to the function when `length(var.subnet_ids) > 0` (the `vpc_config` dynamic block). `var.vpc_id` has no default, so callers who set `subnet_ids = []` to skip VPC attachment must still supply a `vpc_id` to satisfy the SG resource — contradicting the variable's own description ("VPC identifier used when the Lambda function runs inside a VPC"). This produces an orphaned, unused security group and a misleading required variable.

   The SG creation should mirror the `vpc_config` condition:

   ```hcl
   resource "aws_security_group" "lambda" {
     count       = length(var.subnet_ids) > 0 ? 1 : 0
     name        = "${local.name_prefix}-sg"
     description = "Security group for Lambda search runtime"
     vpc_id      = var.vpc_id
     ...
   }
   ```

   And the `vpc_config` reference updated to `aws_security_group.lambda[0].id`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


3. `infrastructure/modules/search_service_lambda/main.tf`, line 77-91 ([link](https://github.com/bytes0211/semantic_search/blob/09d40b60d11e5e638160fc91732f36e1bcac3476/infrastructure/modules/search_service_lambda/main.tf#L77-L91)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`secrets_access` policy created unconditionally with potentially empty `Resource` array**

   When `secret_arn_values = {}`, `values(var.secret_arn_values)` returns `[]`. AWS IAM rejects a policy statement where `"Resource"` is an empty array, causing `terraform apply` to fail with a policy parsing error. The Fargate module guards the equivalent inline policy with `count = length(var.secret_arn_values) > 0 ? 1 : 0`; the Lambda module lacks that guard.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: infrastructure/modules/search_service_lambda/main.tf
   Line: 77-91

   Comment:
   **`secrets_access` policy created unconditionally with potentially empty `Resource` array**

   When `secret_arn_values = {}`, `values(var.secret_arn_values)` returns `[]`. AWS IAM rejects a policy statement where `"Resource"` is an empty array, causing `terraform apply` to fail with a policy parsing error. The Fargate module guards the equivalent inline policy with `count = length(var.secret_arn_values) > 0 ? 1 : 0`; the Lambda module lacks that guard.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: infrastructure/modules/search_service_lambda/main.tf
Line: 93-121

Comment:
**Lambda SG created unconditionally, forcing `vpc_id` on non-VPC deployments**

`aws_security_group.lambda` is created on every invocation of this module, but the SG is only ever attached to the function when `length(var.subnet_ids) > 0` (the `vpc_config` dynamic block). `var.vpc_id` has no default, so callers who set `subnet_ids = []` to skip VPC attachment must still supply a `vpc_id` to satisfy the SG resource — contradicting the variable's own description ("VPC identifier used when the Lambda function runs inside a VPC"). This produces an orphaned, unused security group and a misleading required variable.

The SG creation should mirror the `vpc_config` condition:

```hcl
resource "aws_security_group" "lambda" {
  count       = length(var.subnet_ids) > 0 ? 1 : 0
  name        = "${local.name_prefix}-sg"
  description = "Security group for Lambda search runtime"
  vpc_id      = var.vpc_id
  ...
}
```

And the `vpc_config` reference updated to `aws_security_group.lambda[0].id`.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: infrastructure/modules/search_service_lambda/variables.tf
Line: 202-211

Comment:
**`vpc_id` required even when Lambda is not VPC-attached**

`var.vpc_id` has no default value, making it a required input. However, it is only meaningful when `subnet_ids` is non-empty — yet the unconditionally-created `aws_security_group.lambda` resource always reads it. Callers using Lambda outside a VPC (`subnet_ids = []`) will be forced to supply a dummy VPC ID, which is confusing and error-prone.

Adding a default of `""` and guarding the SG resource on `length(var.subnet_ids) > 0` (paired with the fix above) would make the variable truly optional:

```suggestion
variable "vpc_id" {
  description = "VPC identifier used when the Lambda function runs inside a VPC. Leave empty when subnet_ids is also empty."
  type        = string
  default     = ""
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: infrastructure/modules/search_service_lambda/main.tf
Line: 77-91

Comment:
**`secrets_access` policy created unconditionally with potentially empty `Resource` array**

When `secret_arn_values = {}`, `values(var.secret_arn_values)` returns `[]`. AWS IAM rejects a policy statement where `"Resource"` is an empty array, causing `terraform apply` to fail with a policy parsing error. The Fargate module guards the equivalent inline policy with `count = length(var.secret_arn_values) > 0 ? 1 : 0`; the Lambda module lacks that guard.

```suggestion
resource "aws_iam_role_policy" "secrets_access" {
  count = length(var.secret_arn_values) > 0 ? 1 : 0
  name  = "${local.name_prefix}-secrets"
  role  = aws_iam_role.lambda.id

  policy = jsonencode({
    Version = "2012-10-17"
    Statement = [
      {
        Effect   = "Allow"
        Action   = ["secretsmanager:GetSecretValue", "kms:Decrypt"]
        Resource = values(var.secret_arn_values)
      }
    ]
  })
}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(infra): fixes on PR"](https://github.com/bytes0211/semantic_search/commit/09d40b60d11e5e638160fc91732f36e1bcac3476) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28405628)</sub>

<!-- /greptile_comment -->