### PR TITLE
PR - infra(observability): enable VPC flow logs, extend log retention, add WAF

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Steven Cotton
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -88,6 +88,30 @@ search_service_allowed_ingress_cidrs = [
 search_service_acm_certificate_arn = "arn:aws:acm:us-east-1:123456789012:certificate/abcd1234-..."
 ```
 
+### Web Application Firewall (WAF)
+
+AWS WAFv2 can be attached to the ALB to protect against common web exploits and automated attacks:
+
+- **Development:** Not required; `enable_waf = false` (default) to minimize cost
+- **Production:** Strongly recommended; `enable_waf = true`
+
+When enabled, the module creates a **REGIONAL** WebACL with AWS managed rule groups:
+- `AWSManagedRulesCommonRuleSet` (priority 1) — OWASP Top 10 and CVE protections
+- `AWSManagedRulesKnownBadInputsRuleSet` (priority 2) — Known attack patterns
+
+All rules are in COUNT mode by default (logging only, no blocking) to allow baseline establishment. Once traffic patterns are understood, you can switch individual rules to BLOCK mode.
+
+**Costs:** ~$5/month base fee + $1 per million requests + $0.60 per rule per month (~$1.20 for two managed rule groups).
+
+**To enable WAF:**
+```hcl
+enable_waf = true
+```
+
+**CloudWatch Metrics:** The WebACL emits metrics to the `AWS/WAFV2` namespace with dimensions `Rule` and `WebACL`. These are automatically wired to the observability module's dashboards.
+
+**Custom rule groups:** The `waf_rule_groups` variable (in the Fargate module) can be overridden to add custom managed rule groups or adjust priorities, but the default configuration is suitable for most applications.
+
 ### Private Subnets and NAT Gateway
 
 Fargate tasks run in **private subnets** for security hardening and do not receive public IP addresses. Outbound connectivity to AWS services (ECR, Bedrock, S3) and the internet is provided through a **NAT gateway** or **VPC endpoints**.

--- a/infrastructure/environments/dev/examples/fargate.tfvars.example
+++ b/infrastructure/environments/dev/examples/fargate.tfvars.example
@@ -19,6 +19,10 @@ enable_interface_endpoints = false
 # When false: unrestricted egress (development only, NOT for production)
 # restrict_egress = false
 
+# WAF protection - strongly recommended for production (~$5/mo + $1/million requests)
+# Attaches AWS WAFv2 WebACL with managed rule groups (OWASP Top 10, known bad inputs)
+# enable_waf = true
+
 # ─── Search Service Configuration ─────────────────────────────────────────────
 search_service_container_image = "123456789012.dkr.ecr.us-east-1.amazonaws.com/semantic-search:main"
 

--- a/infrastructure/environments/dev/examples/fargate.tfvars.example
+++ b/infrastructure/environments/dev/examples/fargate.tfvars.example
@@ -19,6 +19,12 @@ enable_interface_endpoints = false
 # When false: unrestricted egress (development only, NOT for production)
 # restrict_egress = false
 
+# VPC Flow Logs - disabled by default; enable for network troubleshooting and security auditing
+# enable_flow_logs             = true
+# flow_log_destination_type    = "cloud-watch-logs"  # or "s3"
+# flow_log_destination_arn     = "arn:aws:logs:us-east-1:123456789012:log-group:/vpc/flow-logs"
+# flow_log_iam_role_arn        = "arn:aws:iam::123456789012:role/vpc-flow-logs-role"  # Required for CloudWatch Logs only
+
 # WAF protection - strongly recommended for production (~$5/mo + $1/million requests)
 # Attaches AWS WAFv2 WebACL with managed rule groups (OWASP Top 10, known bad inputs)
 # enable_waf = true

--- a/infrastructure/environments/dev/main.tf
+++ b/infrastructure/environments/dev/main.tf
@@ -270,7 +270,8 @@ module "search_service_fargate" {
   vpc_cidr                   = var.vpc_cidr
 
   # WAF
-  enable_waf = var.enable_waf
+  enable_waf      = var.enable_waf
+  waf_rule_groups = var.search_service_waf_rule_groups
 
   tags = local.default_tags
 }
@@ -513,7 +514,7 @@ variable "default_az_count" {
 variable "enable_flow_logs" {
   type        = bool
   description = "Whether to enable VPC flow logs. Requires flow_log_destination_arn (and flow_log_iam_role_arn for CloudWatch Logs) when true."
-  default     = true
+  default     = false
 }
 
 variable "flow_log_destination_type" {
@@ -1031,4 +1032,16 @@ variable "enable_waf" {
   type        = bool
   description = "Attach AWS WAFv2 WebACL with managed rule groups to the ALB. Recommended for production environments."
   default     = false
+}
+
+variable "search_service_waf_rule_groups" {
+  type = list(object({
+    name     = string
+    priority = number
+  }))
+  description = "List of AWS managed WAF rule groups to attach to the ALB. Each entry specifies the rule group name and priority."
+  default = [
+    { name = "AWSManagedRulesCommonRuleSet", priority = 1 },
+    { name = "AWSManagedRulesKnownBadInputsRuleSet", priority = 2 }
+  ]
 }

--- a/infrastructure/environments/dev/main.tf
+++ b/infrastructure/environments/dev/main.tf
@@ -269,6 +269,9 @@ module "search_service_fargate" {
   restrict_egress            = var.restrict_egress
   vpc_cidr                   = var.vpc_cidr
 
+  # WAF
+  enable_waf = var.enable_waf
+
   tags = local.default_tags
 }
 
@@ -510,7 +513,7 @@ variable "default_az_count" {
 variable "enable_flow_logs" {
   type        = bool
   description = "Whether to enable VPC flow logs. Requires flow_log_destination_arn (and flow_log_iam_role_arn for CloudWatch Logs) when true."
-  default     = false
+  default     = true
 }
 
 variable "flow_log_destination_type" {
@@ -640,7 +643,7 @@ variable "search_service_platform_version" {
 variable "search_service_log_retention_in_days" {
   type        = number
   description = "CloudWatch Logs retention period for the search service."
-  default     = 14
+  default     = 90
 }
 
 variable "search_service_environment_variables" {
@@ -915,7 +918,7 @@ variable "lambda_secret_arn_values" {
 variable "lambda_log_retention_in_days" {
   type        = number
   description = "CloudWatch Logs retention period for the Lambda runtime."
-  default     = 14
+  default     = 90
 }
 
 variable "lambda_api_gateway_timeout_ms" {
@@ -1021,5 +1024,11 @@ variable "enable_interface_endpoints" {
 variable "restrict_egress" {
   type        = bool
   description = "Tighten security group egress to HTTPS-only to VPC CIDR (requires VPC endpoints for full connectivity)."
+  default     = false
+}
+
+variable "enable_waf" {
+  type        = bool
+  description = "Attach AWS WAFv2 WebACL with managed rule groups to the ALB. Recommended for production environments."
   default     = false
 }

--- a/infrastructure/modules/search_service_fargate/main.tf
+++ b/infrastructure/modules/search_service_fargate/main.tf
@@ -445,3 +445,58 @@ resource "aws_appautoscaling_policy" "request_count" {
   }
 }
 
+# ---------------------------------------------------------------------------
+# WAF WebACL
+# ---------------------------------------------------------------------------
+
+resource "aws_wafv2_web_acl" "this" {
+  count = var.enable_waf ? 1 : 0
+
+  name  = "${local.name_prefix}-waf"
+  scope = var.waf_scope
+
+  default_action {
+    allow {}
+  }
+
+  dynamic "rule" {
+    for_each = var.waf_rule_groups
+    content {
+      name     = rule.value.name
+      priority = rule.value.priority
+
+      override_action {
+        none {}
+      }
+
+      statement {
+        managed_rule_group_statement {
+          vendor_name = "AWS"
+          name        = rule.value.name
+        }
+      }
+
+      visibility_config {
+        cloudwatch_metrics_enabled = true
+        metric_name                = "${local.name_prefix}-${rule.value.name}"
+        sampled_requests_enabled   = true
+      }
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "${local.name_prefix}-waf"
+    sampled_requests_enabled   = true
+  }
+
+  tags = local.common_tags
+}
+
+resource "aws_wafv2_web_acl_association" "this" {
+  count = var.enable_waf ? 1 : 0
+
+  resource_arn = aws_lb.this.arn
+  web_acl_arn  = aws_wafv2_web_acl.this[0].arn
+}
+

--- a/infrastructure/modules/search_service_fargate/main.tf
+++ b/infrastructure/modules/search_service_fargate/main.tf
@@ -453,7 +453,7 @@ resource "aws_wafv2_web_acl" "this" {
   count = var.enable_waf ? 1 : 0
 
   name  = "${local.name_prefix}-waf"
-  scope = var.waf_scope
+  scope = "REGIONAL"
 
   default_action {
     allow {}

--- a/infrastructure/modules/search_service_fargate/variables.tf
+++ b/infrastructure/modules/search_service_fargate/variables.tf
@@ -343,14 +343,3 @@ variable "waf_rule_groups" {
     { name = "AWSManagedRulesKnownBadInputsRuleSet", priority = 2 }
   ]
 }
-
-variable "waf_scope" {
-  type        = string
-  description = "WAF scope - must be REGIONAL for ALB."
-  default     = "REGIONAL"
-
-  validation {
-    condition     = var.waf_scope == "REGIONAL"
-    error_message = "WAF scope must be REGIONAL for Application Load Balancers."
-  }
-}

--- a/infrastructure/modules/search_service_fargate/variables.tf
+++ b/infrastructure/modules/search_service_fargate/variables.tf
@@ -325,3 +325,32 @@ variable "vpc_cidr" {
     error_message = "vpc_cidr must be a non-empty CIDR block when restrict_egress is true."
   }
 }
+
+variable "enable_waf" {
+  type        = bool
+  description = "Whether to provision and attach an AWS WAFv2 WebACL to the ALB."
+  default     = false
+}
+
+variable "waf_rule_groups" {
+  type = list(object({
+    name     = string
+    priority = number
+  }))
+  description = "List of AWS managed WAF rule groups to enable. Each entry specifies the rule group name and priority."
+  default = [
+    { name = "AWSManagedRulesCommonRuleSet", priority = 1 },
+    { name = "AWSManagedRulesKnownBadInputsRuleSet", priority = 2 }
+  ]
+}
+
+variable "waf_scope" {
+  type        = string
+  description = "WAF scope - must be REGIONAL for ALB."
+  default     = "REGIONAL"
+
+  validation {
+    condition     = var.waf_scope == "REGIONAL"
+    error_message = "WAF scope must be REGIONAL for Application Load Balancers."
+  }
+}


### PR DESCRIPTION
chore(infra): enable VPC flow logs, ent log retention

Closes #37

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds three observability/security improvements: VPC flow log support in the `core_network` module (with correct `lifecycle.precondition` guards), extended CloudWatch log retention, and an optional AWS WAFv2 WebACL attached to the ALB. All previous review concerns have been resolved — `waf_scope` is now hardcoded to `"REGIONAL"` and `waf_rule_groups` is threaded through from the environment level.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no P0 or P1 issues; all previous review concerns have been addressed.

All remaining findings are P2 (WAF logging configuration and priority validation), which are best-practice suggestions that don't block correctness or security. The VPC flow log implementation has proper precondition guards, the WAF scope fix is correct, and waf_rule_groups is now surfaced at the environment level.

infrastructure/modules/search_service_fargate/main.tf — consider adding aws_wafv2_web_acl_logging_configuration for full request audit logging.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| infrastructure/modules/search_service_fargate/main.tf | Adds WAF WebACL and ALB association; scope is now correctly hardcoded to REGIONAL; missing aws_wafv2_web_acl_logging_configuration means only sampled requests are captured |
| infrastructure/modules/search_service_fargate/variables.tf | Adds enable_waf and waf_rule_groups variables; waf_scope variable removed, addressing the previous review comment |
| infrastructure/modules/core_network/main.tf | Adds aws_flow_log resource with correct lifecycle preconditions guarding both the destination ARN and IAM role requirements |
| infrastructure/environments/dev/main.tf | Adds flow log variables (enable_flow_logs, flow_log_destination_type/arn, flow_log_iam_role_arn) and threads them to core_network; adds enable_waf and search_service_waf_rule_groups, both correctly threaded to the fargate module |
| infrastructure/environments/dev/examples/fargate.tfvars.example | Updated with commented-out examples for VPC flow logs and WAF; examples are accurate and include cost guidance |

</details>


</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `infrastructure/environments/dev/main.tf`, line 513-535 ([link](https://github.com/bytes0211/semantic_search/blob/75b02c0e76b845c01ca8012a5c9703e25fec271a/infrastructure/environments/dev/main.tf#L513-L535)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`enable_flow_logs = true` default will break `terraform plan` for every new user**

   `enable_flow_logs` defaults to `true` here, but `flow_log_destination_arn` defaults to `""` and `flow_log_iam_role_arn` also defaults to `""`. The child module (`core_network/main.tf`) has lifecycle preconditions that fire at plan time:
   - `flow_log_destination_arn != ""` when flow logs are enabled
   - `flow_log_iam_role_arn != ""` when `flow_log_destination_type == "cloud-watch-logs"`

   With these defaults, `terraform plan` fails immediately for any deployment that doesn't explicitly supply the ARNs. The `fargate.tfvars.example` provides no example values for these variables, so operators following the example will hit a broken plan with no obvious fix.

   Either flip the default to `false` (consistent with the `core_network` module's own default), or add the required ARN variables to `fargate.tfvars.example` with placeholder values and clear comments.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: infrastructure/environments/dev/main.tf
   Line: 513-535

   Comment:
   **`enable_flow_logs = true` default will break `terraform plan` for every new user**

   `enable_flow_logs` defaults to `true` here, but `flow_log_destination_arn` defaults to `""` and `flow_log_iam_role_arn` also defaults to `""`. The child module (`core_network/main.tf`) has lifecycle preconditions that fire at plan time:
   - `flow_log_destination_arn != ""` when flow logs are enabled
   - `flow_log_iam_role_arn != ""` when `flow_log_destination_type == "cloud-watch-logs"`

   With these defaults, `terraform plan` fails immediately for any deployment that doesn't explicitly supply the ARNs. The `fargate.tfvars.example` provides no example values for these variables, so operators following the example will hit a broken plan with no obvious fix.

   Either flip the default to `false` (consistent with the `core_network` module's own default), or add the required ARN variables to `fargate.tfvars.example` with placeholder values and clear comments.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: infrastructure/modules/search_service_fargate/main.tf
Line: 452-501

Comment:
**WAF ACL has no full-request logging configured**

`sampled_requests_enabled = true` only captures a fraction of matched/blocked traffic. Without an `aws_wafv2_web_acl_logging_configuration` resource, there's no audit trail of all blocked requests — which limits the ability to tune rules and investigate incidents. Consider adding a logging configuration pointing to a Kinesis Firehose, S3 bucket, or CloudWatch Log Group:

```hcl
resource "aws_wafv2_web_acl_logging_configuration" "this" {
  count                   = var.enable_waf ? 1 : 0
  log_destination_configs = [var.waf_log_destination_arn]
  resource_arn            = aws_wafv2_web_acl.this[0].arn
}
```

This would require a new `waf_log_destination_arn` variable (optional, gated on `enable_waf`).

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: infrastructure/modules/search_service_fargate/variables.tf
Line: 335-345

Comment:
**`waf_rule_groups` has no unique-priority validation**

The list allows callers to supply duplicate `priority` values. AWS WAF will reject the `aws_wafv2_web_acl` create/update with a `WAFDuplicateItemException` at apply time, which can be confusing. A `validations` block would surface the problem earlier:

```hcl
  validation {
    condition = length(var.waf_rule_groups) == length(distinct([for r in var.waf_rule_groups : r.priority]))
    error_message = "Each waf_rule_groups entry must have a unique priority."
  }
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(infra)fixes that address comments on..."](https://github.com/bytes0211/semantic_search/commit/5c2f83eb36f1cd504ed834d306795c6494bd7680) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28438134)</sub>

<!-- /greptile_comment -->