### PR TITLE
PR - infra(fargate): raise desired_count above 1 and enable multi-AZ

### DIFF
--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -112,6 +112,33 @@ enable_waf = true
 
 **Custom rule groups:** The `waf_rule_groups` variable (in the Fargate module) can be overridden to add custom managed rule groups or adjust priorities, but the default configuration is suitable for most applications.
 
+### High Availability and Multi-AZ Deployment
+
+For production deployments, run at least **2 tasks** distributed across **2 availability zones** to ensure zero-downtime during deployments and resilience to single-task or AZ failures.
+
+**Key configuration:**
+```hcl
+# Task count controls
+search_service_desired_count = 2   # Initial and target task count
+search_service_min_capacity  = 2   # Minimum tasks (autoscaling floor)
+search_service_max_capacity  = 6   # Maximum tasks (autoscaling ceiling)
+
+# Multi-AZ is automatic when default_az_count >= 2 (default)
+default_az_count = 2               # Subnets span this many AZs
+```
+
+**Autoscaling:** The module includes application autoscaling with CPU-based target tracking (default 60%) and optional request-count-based scaling. Tasks scale between `min_capacity` and `max_capacity` based on load.
+
+**Deployment behavior:**
+- **Single task (desired_count = 1):** Rolling updates cause downtime while the new task starts
+- **Multiple tasks (desired_count >= 2):** ECS drains connections from old tasks gracefully while new tasks come online; zero downtime
+
+**Cost impact:** Running 2 tasks instead of 1 doubles Fargate compute costs (~$30/month → ~$60/month for default sizing). This is offset by improved availability SLA.
+
+**Development vs Production:**
+- **Development:** `desired_count = 1` is acceptable to minimize cost
+- **Production:** `desired_count >= 2` is strongly recommended for HA
+
 ### Private Subnets and NAT Gateway
 
 Fargate tasks run in **private subnets** for security hardening and do not receive public IP addresses. Outbound connectivity to AWS services (ECR, Bedrock, S3) and the internet is provided through a **NAT gateway** or **VPC endpoints**.

--- a/infrastructure/environments/dev/examples/fargate.tfvars.example
+++ b/infrastructure/environments/dev/examples/fargate.tfvars.example
@@ -4,6 +4,9 @@ aws_region                        = "us-east-1"
 
 search_runtime                    = "fargate"
 embedding_backend                 = "bedrock"
+# IMPORTANT: FAISS is an in-memory vector store - each task loads its own copy from S3.
+# With desired_count > 1, ingestion updates affect only one task, causing inconsistent
+# search results. For multi-task HA, use "qdrant" or "pgvector" instead.
 vector_store                      = "faiss"
 ingestion_mode                    = "batch"
 
@@ -45,7 +48,9 @@ search_service_allowed_ingress_cidrs = [
 search_service_acm_certificate_arn = "arn:aws:acm:us-east-1:123456789012:certificate/abcd1234-5678-90ef-ghij-klmnopqrstuv"
 
 # High Availability - run at least 2 tasks across 2 AZs (default_az_count = 2)
-# This ensures zero-downtime deployments and resilience to single-task/AZ failures
+# This ensures zero-downtime deployments and resilience to single-task failures.
+# Note: with create_nat_gateway=true a single NAT GW remains an egress SPOF;
+# set enable_interface_endpoints=true for full AZ-level egress resilience.
 search_service_desired_count = 2
 search_service_min_capacity       = 2
 search_service_max_capacity       = 6

--- a/infrastructure/environments/dev/examples/fargate.tfvars.example
+++ b/infrastructure/environments/dev/examples/fargate.tfvars.example
@@ -44,6 +44,8 @@ search_service_allowed_ingress_cidrs = [
 # When set, HTTP (port 80) redirects to HTTPS (port 443)
 search_service_acm_certificate_arn = "arn:aws:acm:us-east-1:123456789012:certificate/abcd1234-5678-90ef-ghij-klmnopqrstuv"
 
+# High Availability - run at least 2 tasks across 2 AZs (default_az_count = 2)
+# This ensures zero-downtime deployments and resilience to single-task/AZ failures
 search_service_desired_count = 2
 search_service_min_capacity       = 2
 search_service_max_capacity       = 6


### PR DESCRIPTION
chore(infra): raise count and enable multi az

Closes #38

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR raises `search_service_desired_count` to 2, sets matching `min_capacity`/`max_capacity` bounds, and adds a README section documenting HA and multi-AZ deployment behaviour. The README additions are accurate and well-aligned with the existing NAT-gateway SPOF caveat.

- The example file warns that FAISS with `desired_count > 1` causes inconsistent search results, but still sets `vector_store = \"faiss\"` alongside `desired_count = 2` — the broken combination the warning describes. Anyone copying the file as-is gets a silently inconsistent deployment.

<h3>Confidence Score: 4/5</h3>

Mergeable after resolving the FAISS / desired_count contradiction in the example file.

The README changes are clean and correct. The one blocking issue is that the example file demonstrates a configuration its own inline comment explicitly warns against — FAISS with desired_count > 1 — which will mislead operators who follow the file literally.

infrastructure/environments/dev/examples/fargate.tfvars.example — the vector_store value must be reconciled with the new desired_count setting.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| infrastructure/environments/dev/examples/fargate.tfvars.example | Raises desired_count to 2 and sets min_capacity/max_capacity for HA, but leaves vector_store as "faiss" — directly contradicting the inline warning that FAISS with desired_count > 1 produces inconsistent search results. |
| infrastructure/README.md | Adds a new "High Availability and Multi-AZ Deployment" section documenting desired_count, autoscaling, and deployment behaviour; content is accurate and consistent with the NAT gateway SPOF caveat already present in the Private Subnets section. |

</details>


</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `infrastructure/environments/dev/examples/fargate.tfvars.example`, line 7-49 ([link](https://github.com/bytes0211/semantic_search/blob/06f0fcc38156d482d2f37c3bf45df233fa151103/infrastructure/environments/dev/examples/fargate.tfvars.example#L7-L49)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **FAISS + multiple tasks creates in-memory state inconsistency**

   `vector_store = "faiss"` with `search_service_desired_count = 2` means each Fargate task boots its own in-memory FAISS index loaded from the shared S3 snapshot. Any ingestion event processed by one task updates only that task's in-memory index; the other task continues serving the older snapshot until it restarts and reloads from S3. The ALB will round-robin search queries across both tasks, so the same query can return different result sets depending on which task handles it.

   FAISS's S3-backed design is fundamentally single-writer / eventual-consistency-on-restart. For multi-task HA, consider switching to a client/server vector store (`qdrant` or `pgvector`) that all tasks share, or keep `desired_count = 1` while FAISS remains the vector backend.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: infrastructure/environments/dev/examples/fargate.tfvars.example
   Line: 7-49

   Comment:
   **FAISS + multiple tasks creates in-memory state inconsistency**

   `vector_store = "faiss"` with `search_service_desired_count = 2` means each Fargate task boots its own in-memory FAISS index loaded from the shared S3 snapshot. Any ingestion event processed by one task updates only that task's in-memory index; the other task continues serving the older snapshot until it restarts and reloads from S3. The ALB will round-robin search queries across both tasks, so the same query can return different result sets depending on which task handles it.

   FAISS's S3-backed design is fundamentally single-writer / eventual-consistency-on-restart. For multi-task HA, consider switching to a client/server vector store (`qdrant` or `pgvector`) that all tasks share, or keep `desired_count = 1` while FAISS remains the vector backend.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: infrastructure/environments/dev/examples/fargate.tfvars.example
Line: 7-10

Comment:
**FAISS + `desired_count = 2` is a self-contradicting example**

The comment on lines 7–9 explicitly states that running FAISS with `desired_count > 1` causes inconsistent search results (each task loads its own independent in-memory index). Yet `vector_store` remains `"faiss"` and `search_service_desired_count` is set to `2` — the exact combination the comment warns against. Anyone copying this file verbatim gets a silently broken multi-task deployment where one task's index diverges from another's after any ingestion run.

Either switch the example to a shared-state store that supports multi-task HA:
```suggestion
# IMPORTANT: FAISS is an in-memory vector store - each task loads its own copy from S3.
# With desired_count > 1, ingestion updates affect only one task, causing inconsistent
# search results. For multi-task HA, use "qdrant" or "pgvector" instead.
vector_store                      = "qdrant"
```
Or comment out the `desired_count = 2` lines below with a note that users must first switch away from FAISS, so the example never demonstrates the broken combination.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(infra): address comments on PR 45 co..."](https://github.com/bytes0211/semantic_search/commit/99e93d5485742334c1d27954d76b9267e255af87) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28441898)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->